### PR TITLE
Also trigger on fas.role.update.

### DIFF
--- a/fedmsg_fasclient.py
+++ b/fedmsg_fasclient.py
@@ -20,6 +20,7 @@ class FasClientConsumer(fedmsg.consumers.FedmsgConsumer):
     # distinctions).  But then we'll filter later in our consume() method.
     topic = '*'
     interesting_topics = [
+        'org.fedoraproject.prod.fas.role.update',
         'org.fedoraproject.prod.fas.group.member.sponsor',
         'org.fedoraproject.prod.fas.group.member.remove',
         'org.fedoraproject.prod.fas.user.update',


### PR DESCRIPTION
So, I applied to the gitsupybot-fedora group, and just sat there.
Later, @ianweller sponsored me which really added me to the group.  It
triggered a `fas.role.update` message from fas.

However, hosted03 never got a new run of fas client and thus never
learned that I was now in this group (and should have privs to make
releases of stuff).

This should fix that.
